### PR TITLE
fix (web): catch case where color is transparent

### DIFF
--- a/lib/simple_shadow.dart
+++ b/lib/simple_shadow.dart
@@ -35,10 +35,12 @@ class SimpleShadow extends StatelessWidget {
               ),
               child: Opacity(
                 opacity: opacity,
-                child: ColorFiltered(
-                  colorFilter: ColorFilter.mode(color, BlendMode.srcATop),
-                  child: child,
-                ),
+                child: color.alpha == 0
+                    ? child
+                    : ColorFiltered(
+                        colorFilter: ColorFilter.mode(color, BlendMode.srcATop),
+                        child: child,
+                      ),
               ),
             ),
           ),

--- a/lib/simple_shadow.dart
+++ b/lib/simple_shadow.dart
@@ -22,29 +22,29 @@ class SimpleShadow extends StatelessWidget {
   Widget build(BuildContext context) {
     return Stack(
       children: <Widget>[
-        Transform.translate(
-          offset: offset,
-          child: ImageFiltered(
-            imageFilter: ImageFilter.blur(sigmaY: sigma, sigmaX: sigma, tileMode: TileMode.decal),
-            child: Container(
-              decoration: BoxDecoration(
-                border: Border.all(
-                  color: Colors.transparent,
-                  width: 0,
+        if (color.alpha != 0)
+          Transform.translate(
+            offset: offset,
+            child: ImageFiltered(
+              imageFilter: ImageFilter.blur(
+                  sigmaY: sigma, sigmaX: sigma, tileMode: TileMode.decal),
+              child: Container(
+                decoration: BoxDecoration(
+                  border: Border.all(
+                    color: Colors.transparent,
+                    width: 0,
+                  ),
                 ),
-              ),
-              child: Opacity(
-                opacity: opacity,
-                child: color.alpha == 0
-                    ? child
-                    : ColorFiltered(
-                        colorFilter: ColorFilter.mode(color, BlendMode.srcATop),
-                        child: child,
-                      ),
+                child: Opacity(
+                  opacity: opacity,
+                  child: ColorFiltered(
+                    colorFilter: ColorFilter.mode(color, BlendMode.srcATop),
+                    child: child,
+                  ),
+                ),
               ),
             ),
           ),
-        ),
         child,
       ],
     );


### PR DESCRIPTION
Hi!

There is an edge case for flutter web (testing with `3.3.9-stable`), that the color filter crashes if it has a transparent color, this fix doesn't apply the shadow if the color is transparent.

Flutter issue ref: https://github.com/flutter/flutter/issues/61780#issuecomment-684115059